### PR TITLE
Fix double-stringified content in proposal MCP tools

### DIFF
--- a/lib/ai/tools/proposals-tools.ts
+++ b/lib/ai/tools/proposals-tools.ts
@@ -160,7 +160,7 @@ export function createProposalsTools(context: ToolContext) {
 							company: input.company,
 							recipient: input.recipient,
 							preparator: userId, // Automatically set to the user making the request
-							content: JSON.stringify(proposalContent),
+							content: proposalContent,
 							expiry_date: expiryDate,
 							status: input.status || 'Draft',
 							proposal_number: proposalNumber,
@@ -235,12 +235,7 @@ export function createProposalsTools(context: ToolContext) {
 					const cleanUpdates: Partial<Proposal> = {};
 					Object.entries(updates).forEach(([key, value]) => {
 						if (value !== undefined) {
-							// Stringify content field (validation moved to client-side)
-							if (key === 'content') {
-								cleanUpdates[key as keyof Proposal] = JSON.stringify(value) as any;
-							} else {
-								cleanUpdates[key as keyof Proposal] = value as any;
-							}
+							cleanUpdates[key as keyof Proposal] = value as any;
 						}
 					});
 


### PR DESCRIPTION
## Summary

- Remove explicit `JSON.stringify()` on the `content` field in `createProposal` and `updateProposal`.
- Supabase serializes object inputs into `json` columns correctly on its own — the manual stringify caused content to be stored as a JSON-string value (the JSON object wrapped in quotes) instead of a JSON-object value.

## Why this matters

The Lexical editor on the client side expects an object. When proposals are created or updated through the MCP tools, the editor instead receives a string and crashes with **Application Error**, making the proposal unviewable in the UI.

## Reproduction (before this fix)

1. Use the `updateProposal` MCP tool to update `content` with a Lexical object: `{ root: { children: [...] } }`.
2. Refetch the proposal — `content` is now a JSON-encoded string instead of an object.
3. Open the proposal in the Proposit UI → Application Error.

## After this fix

`updateProposal` and `createProposal` pass the Lexical object straight through to Supabase. The `json` column receives a structured object as expected, and the editor renders the proposal normally.

## Test plan

- [ ] Create a new proposal via `createProposal` MCP tool with a Lexical content object → open in UI, content renders.
- [ ] Update an existing proposal via `updateProposal` MCP tool with a new Lexical content object → open in UI, content renders.
- [ ] Round-trip: `updateProposal` → `getProposal` → `content` is an object, not a string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)